### PR TITLE
Added configuration parameter lockDir to specify where proto.lock lives

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ must be added to your project's pom.xml file in order for this plugin to work.
             <configuration>
                 <!-- Optional alternative protos location -->
                 <protoSourceRoot>src/main/proto</protoSourceRoot>
+                <!-- Optional alternative proto.lock location -->
+                <lockDir>src/main/proto</lockDir>
             </configuration>
             <executions>
                 <execution>
@@ -61,6 +63,7 @@ must be added to your project's pom.xml file in order for this plugin to work.
 ## Configuration
 
 * `<protoSourceRoot>` (`${basedir}/src/main/proto`) - The directory where proto sources can be found.
+* `<lockDir>` (defaults to root of proto files) - The directory where proto.lock will be kept.
 * `<options>` (empty) - Additional [command line options](https://github.com/nilslice/protolock#usage) to pass to protolock.
 
 ```xml
@@ -68,6 +71,7 @@ must be added to your project's pom.xml file in order for this plugin to work.
     <plugins>
         <protoSourceRoot>src/main/proto</protoSourceRoot>
         <options>--ignore=target/</options>
+        <lockDir>${project.basedir}</lockDir>
     </plugins>
 </configuration>
 ```

--- a/src/main/java/com/salesforce/servicelibs/BackwardsCompatibilityCheckMojo.java
+++ b/src/main/java/com/salesforce/servicelibs/BackwardsCompatibilityCheckMojo.java
@@ -195,6 +195,11 @@ public class BackwardsCompatibilityCheckMojo
                 options = "";
             }
 
+            if (options.toUpperCase().contains("--LOCKDIR")) {
+                throw new MojoFailureException("lockDir location must be specified on the plugin and not as "
+                        + "an option passed to protolock command");
+            }
+
             // Build option for lock file location
             String _lockDir = null;
             String lockDirOption = "";
@@ -205,6 +210,7 @@ public class BackwardsCompatibilityCheckMojo
             } else {
                 _lockDir = protoSourceRoot;
             }
+
 
             Path lockFile = Paths.get(_lockDir,"proto.lock");
             if (!Files.exists(lockFile)) {


### PR DESCRIPTION
Passing `<option>--lockdir=somewhere_else</option>` does not work, the plugin always checks the proto root directory for `proto.lock` .

This PR adds a new configuration parameter `lockDir`