### PR TITLE
Add property to force update proto.lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ track of the state of the .proto files. This file is updated when a non-breaking
 is made, and should be checked in along with any other changes.
 
 It is also possible to force any breaking changes and reset the current state
-by deleting the proto.lock file. It will then reinitialize the next time the
+by either 
+* deleting the proto.lock file. It will then reinitialize the next time the
 plugin is run.
+* or by specifying parameter property `acceptBreakingChanges` (`-DacceptBreakingChanges=true`)
 
 #### Maintaining Backwards Compatibility
 In order to maintain backwards compatibility for your set of .proto files, a few

--- a/src/test/resources/unit/project-to-test/pom-allowbreakingchanges.xml
+++ b/src/test/resources/unit/project-to-test/pom-allowbreakingchanges.xml
@@ -1,0 +1,37 @@
+<!--
+  ~  Copyright (c) 2018, salesforce.com, inc.
+  ~  All rights reserved.
+  ~  Licensed under the BSD 3-Clause license.
+  ~  For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+  -->
+
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.salesforce.servicelibs.unit</groupId>
+    <artifactId>project-to-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>Test Backwards Compatibility Mojo</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.salesforce.servicelibs</groupId>
+                <artifactId>proto-backwards-compatibility</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <configuration>
+                    <!-- Optional alternative protos location -->
+                    <protoSourceRoot>src/test/resources/unit/proto</protoSourceRoot>
+                    <allowBreakingChanges>true</allowBreakingChanges>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>backwards-compatibility-check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
This is an alternative to deleting `proto.lock` when this is not viable (ie it is used by other plugins)