### PR TITLE
Use os-maven-plugin's name + arch directly instead of classifier

### DIFF
--- a/src/main/java/com/salesforce/servicelibs/BackwardsCompatibilityCheckMojo.java
+++ b/src/main/java/com/salesforce/servicelibs/BackwardsCompatibilityCheckMojo.java
@@ -111,11 +111,14 @@ public class BackwardsCompatibilityCheckMojo extends AbstractMojo {
      * @throws MojoFailureException   thrown when compatibility check fails.
      */
     public void execute() throws MojoExecutionException, MojoFailureException {
-        final String classifier = project.getProperties().getProperty("os.detected.classifier");
-        if (classifier == null) {
+        final String name = project.getProperties().getProperty("os.detected.name");
+        final String arch = project.getProperties().getProperty("os.detected.arch");
+        if (name == null || arch == null) {
             getLog().error("Add os-maven-plugin to your POM. https://github.com/trustin/os-maven-plugin");
             throw new MojoExecutionException("Unable to detect OS type.");
         }
+
+        final String classifier = name + "-" + arch;
 
         try {
             protolockPluginDirectory = protolockPluginDirectory.getCanonicalFile();

--- a/src/test/java/com/salesforce/servicelibs/AllowBreakingChangesMojoTest.java
+++ b/src/test/java/com/salesforce/servicelibs/AllowBreakingChangesMojoTest.java
@@ -12,7 +12,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
-import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -80,20 +79,7 @@ public class AllowBreakingChangesMojoTest
         assertTrue(pom.exists());
         myMojo = (BackwardsCompatibilityCheckMojo) lookupConfiguredMojo(pom, "backwards-compatibility-check");
         assertNotNull(myMojo);
-        Model m = new Model();
-        String classifier = System.getProperty("os.name").toLowerCase();
-        if ((classifier.contains("mac"))) {
-            classifier = "osx-x86_64";
-        } else if (classifier.contains("nux")) {
-            classifier = "linux-x86_64";
-        } else if (classifier.contains("windows")) {
-            classifier = "windows-x86_64";
-        }
-
-        m.addProperty("os.detected.classifier", classifier);
-        Build b = new Build();
-        b.setDirectory(System.getProperty("user.dir") + testDir);
-        m.setBuild(b);
+        Model m = getModel();
         myMojo.project = new MavenProject(m);
     }
 

--- a/src/test/java/com/salesforce/servicelibs/BasicMojoTest.java
+++ b/src/test/java/com/salesforce/servicelibs/BasicMojoTest.java
@@ -12,8 +12,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
-import org.apache.maven.model.Build;
-import org.apache.maven.model.Model;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
@@ -25,7 +23,6 @@ import org.junit.Test;
 public class BasicMojoTest
     extends BetterAbstractMojoTestCase {
 
-    final String testDir = "/src/test/resources/unit/";
     BackwardsCompatibilityCheckMojo myMojo;
 
     /**
@@ -135,21 +132,7 @@ public class BasicMojoTest
         assertTrue(pom.exists());
         myMojo = (BackwardsCompatibilityCheckMojo) lookupConfiguredMojo(pom, "backwards-compatibility-check");
         assertNotNull(myMojo);
-        Model m = new Model();
-        String classifier = System.getProperty("os.name").toLowerCase();
-        if ((classifier.contains("mac"))) {
-            classifier = "osx-x86_64";
-        } else if (classifier.contains("nux")) {
-            classifier = "linux-x86_64";
-        } else if (classifier.contains("windows")) {
-            classifier = "windows-x86_64";
-        }
-
-        m.addProperty("os.detected.classifier", classifier);
-        Build b = new Build();
-        b.setDirectory(System.getProperty("user.dir") + testDir);
-        m.setBuild(b);
-        myMojo.project = new MavenProject(m);
+        myMojo.project = new MavenProject(getModel());
     }
 
     /**

--- a/src/test/java/com/salesforce/servicelibs/BetterAbstractMojoTestCase.java
+++ b/src/test/java/com/salesforce/servicelibs/BetterAbstractMojoTestCase.java
@@ -17,6 +17,8 @@ import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionRequestPopulator;
 import org.apache.maven.execution.MavenExecutionResult;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Model;
 import org.apache.maven.plugin.Mojo;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.project.MavenProject;
@@ -32,6 +34,8 @@ import org.eclipse.aether.repository.LocalRepository;
  * @author ahgittin (https://github.com/ahgittin/license-audit-maven-plugin)
  */
 public abstract class BetterAbstractMojoTestCase extends AbstractMojoTestCase {
+
+    final String testDir = "/src/test/resources/unit/";
 
     protected MavenSession newMavenSession() {
         try {
@@ -97,4 +101,29 @@ public abstract class BetterAbstractMojoTestCase extends AbstractMojoTestCase {
         return lookupConfiguredMojo(project, goal);
     }
 
+
+    protected Model getModel() {
+        Model m = new Model();
+        String name = System.getProperty("os.name").toLowerCase();
+        String arch;
+        if ((name.contains("mac"))) {
+            name = "osx-x86_64";
+            arch = "x86_64";
+        } else if (name.contains("nux")) {
+            name = "linux";
+            arch = "x86_64";
+        } else if (name.contains("windows")) {
+            name = "windows";
+            arch = "x86_64";
+        } else {
+            arch = "";
+        }
+
+        m.addProperty("os.detected.name", name);
+        m.addProperty("os.detected.arch", arch);
+        Build b = new Build();
+        b.setDirectory(System.getProperty("user.dir") + testDir);
+        m.setBuild(b);
+        return m;
+    }
 }

--- a/src/test/java/com/salesforce/servicelibs/PluginMojoTest.java
+++ b/src/test/java/com/salesforce/servicelibs/PluginMojoTest.java
@@ -12,8 +12,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
-import org.apache.maven.model.Build;
-import org.apache.maven.model.Model;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
@@ -28,7 +26,6 @@ import org.junit.Test;
 public class PluginMojoTest
     extends BetterAbstractMojoTestCase {
 
-    final String testDir = "/src/test/resources/unit/";
     BackwardsCompatibilityCheckMojo myMojo;
 
     /**
@@ -84,21 +81,7 @@ public class PluginMojoTest
         myMojo = (BackwardsCompatibilityCheckMojo) lookupConfiguredMojo(pom, "backwards-compatibility-check");
         assertNotNull(myMojo);
 
-        String classifier = System.getProperty("os.name").toLowerCase();
-        if ((classifier.contains("mac"))) {
-            classifier = "osx-x86_64";
-        } else if (classifier.contains("nux")) {
-            classifier = "linux-x86_64";
-        } else if (classifier.contains("windows")) {
-            classifier = "windows-x86_64";
-        }
-
-        Model m = new Model();
-        m.addProperty("os.detected.classifier", classifier);
-        Build b = new Build();
-        b.setDirectory(System.getProperty("user.dir") + testDir);
-        m.setBuild(b);
-        myMojo.project = new MavenProject(m);
+        myMojo.project = new MavenProject(getModel());
         myMojo.project.setArtifact(myMojo.repositorySystem.createArtifact("com.salesforce.servicelibs.unit",
                 "project-to-test", "1.0-SNAPSHOT", "pom"));
 

--- a/src/test/java/com/salesforce/servicelibs/PomOnlyMojoTest.java
+++ b/src/test/java/com/salesforce/servicelibs/PomOnlyMojoTest.java
@@ -12,8 +12,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
-import org.apache.maven.model.Build;
-import org.apache.maven.model.Model;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
@@ -25,7 +23,6 @@ import org.junit.Test;
 public class PomOnlyMojoTest
     extends BetterAbstractMojoTestCase {
 
-    final String testDir = "/src/test/resources/unit/";
     BackwardsCompatibilityCheckMojo myMojo;
 
     /**
@@ -79,21 +76,7 @@ public class PomOnlyMojoTest
         assertTrue(pom.exists());
         myMojo = (BackwardsCompatibilityCheckMojo) lookupConfiguredMojo(pom, "backwards-compatibility-check");
         assertNotNull(myMojo);
-        Model m = new Model();
-        String classifier = System.getProperty("os.name").toLowerCase();
-        if ((classifier.contains("mac"))) {
-            classifier = "osx-x86_64";
-        } else if (classifier.contains("nux")) {
-            classifier = "linux-x86_64";
-        } else if (classifier.contains("windows")) {
-            classifier = "windows-x86_64";
-        }
-
-        m.addProperty("os.detected.classifier", classifier);
-        Build b = new Build();
-        b.setDirectory(System.getProperty("user.dir") + testDir);
-        m.setBuild(b);
-        myMojo.project = new MavenProject(m);
+        myMojo.project = new MavenProject(getModel());
     }
 
     /**


### PR DESCRIPTION
We want to use os-maven-plugin's `classifierWithLikes`, however doing so causes this plugin to look for linux-flavoured binary which does not exist in this project (nor does it need to).

According to the [docs](https://github.com/trustin/os-maven-plugin#property-osdetectedclassifier) the `classifier` is just short for `name`-`arch` , so this change should preserve the current functionality while allowing for more flexiblity whenever linux flavours executables are necessary.



